### PR TITLE
Create .gitattributes for GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Prevent GitHub from displaying comments within JSON files as errors.
+*.json linguist-language=JSON-with-Comments


### PR DESCRIPTION
This should prevent GitHub from highlighting comments in red:

<img width="592" height="400" alt="image" src="https://github.com/user-attachments/assets/90df1bc0-e5c0-4d46-a509-7a58636687fe" />

becomes 

<img width="580" height="397" alt="image" src="https://github.com/user-attachments/assets/06d1d901-cc72-4fc7-b81a-68df06e62545" />
